### PR TITLE
fix isFunEntrySVFGNode in SVFG.cpp

### DIFF
--- a/lib/Graphs/SVFG.cpp
+++ b/lib/Graphs/SVFG.cpp
@@ -665,7 +665,7 @@ const SVFFunction* SVFG::isFunEntrySVFGNode(const SVFGNode* node) const
     else if(const InterMSSAPHISVFGNode* mphi = SVFUtil::dyn_cast<InterMSSAPHISVFGNode>(node))
     {
         if(mphi->isFormalINPHI())
-            return phi->getFun();
+            return mphi->getFun();
     }
     return nullptr;
 }


### PR DESCRIPTION
fix an error in isFunEntrySVFGNode, which might produce: "error: ‘this’ pointer is null [-Werror=nonnull]" when compiling